### PR TITLE
[feature] #26: 카테고리 단건 조회, 수정, 삭제 API

### DIFF
--- a/product/src/main/java/com/sparta/product/application/dtos/category/CategoryResponseDto.java
+++ b/product/src/main/java/com/sparta/product/application/dtos/category/CategoryResponseDto.java
@@ -1,0 +1,40 @@
+package com.sparta.product.application.dtos.category;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sparta.product.domain.core.Category;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CategoryResponseDto(
+        @JsonProperty("category_id") Long categoryId,
+        @JsonProperty("category_name") String categoryName,
+        @JsonProperty("is_deleted") Boolean isDeleted,
+        @JsonProperty("is_public") Boolean isPublic,
+        @JsonProperty("created_at") LocalDateTime createdAt,
+        @JsonProperty("updated_at") LocalDateTime updatedAt
+) {
+
+    public static CategoryResponseDto forUserOrSellerFrom(Category category) {
+        return new CategoryResponseDto(
+                category.getId(),
+                category.getName(),
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static CategoryResponseDto forMasterFrom(Category category) {
+        return new CategoryResponseDto(
+                category.getId(),
+                category.getName(),
+                category.isDeleted(),
+                category.isPublic(),
+                category.getCreatedAt(),
+                category.getUpdatedAt()
+        );
+    }
+}

--- a/product/src/main/java/com/sparta/product/application/dtos/category/CategoryUpdateRequestDto.java
+++ b/product/src/main/java/com/sparta/product/application/dtos/category/CategoryUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.sparta.product.application.dtos.category;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CategoryUpdateRequestDto(
+        @JsonProperty("category_name") String categoryName,
+        @JsonProperty("is_public") Boolean isPublic
+) {
+}

--- a/product/src/main/java/com/sparta/product/application/service/CategoryService.java
+++ b/product/src/main/java/com/sparta/product/application/service/CategoryService.java
@@ -2,7 +2,10 @@ package com.sparta.product.application.service;
 
 import com.sparta.product.application.dtos.Response;
 import com.sparta.product.application.dtos.category.CategoryRequestDto;
+import com.sparta.product.application.dtos.category.CategoryResponseDto;
+import com.sparta.product.application.dtos.category.CategoryUpdateRequestDto;
 import com.sparta.product.application.exception.category.AlreadyExistCategoryException;
+import com.sparta.product.application.exception.category.NotFoundCategoryException;
 import com.sparta.product.application.exception.common.ForbiddenRoleException;
 import com.sparta.product.domain.common.UserRoleEnum;
 import com.sparta.product.domain.core.Category;
@@ -29,8 +32,46 @@ public class CategoryService {
         return new Response<>(HttpStatus.CREATED.value(), "카테고리 등록 완료", null);
     }
 
+    @Transactional(readOnly = true)
+    public Response<CategoryResponseDto> getCategory(Long categoryId, String role) {
+        return new Response<>(HttpStatus.OK.value(),
+                "OK",
+                role.equals(UserRoleEnum.MASTER.toString()) ?
+                        CategoryResponseDto.forMasterFrom(categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new))
+                        : CategoryResponseDto.forUserOrSellerFrom(categoryRepository.findByIdAndIsDeletedFalseAndIsPublicTrue(categoryId).orElseThrow(NotFoundCategoryException::new)));
+    }
+
+    @Transactional
+    public Response<Void> updateCategory(Long categoryId, String role, CategoryUpdateRequestDto categoryUpdateRequestDto) {
+        checkIsMaster(role);
+        if (categoryUpdateRequestDto.categoryName() != null) {
+            checkIsExistCategory(categoryUpdateRequestDto);
+        }
+
+        Category category = categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new);
+        category.updateFrom(categoryUpdateRequestDto);
+
+        return new Response<>(HttpStatus.OK.value(), "수정 완료.", null);
+    }
+
+    @Transactional
+    public Response<Void> softDeleteCategory(Long categoryId, String role) {
+        checkIsMaster(role);
+
+        Category category = categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new);
+        category.updateIsDeleted(true);
+
+        return new Response<>(HttpStatus.OK.value(), "삭제 완료.", null);
+    }
+
+    private void checkIsExistCategory(CategoryUpdateRequestDto categoryUpdateRequestDto) {
+        if (categoryRepository.existsByName(categoryUpdateRequestDto.categoryName())) {
+            throw new AlreadyExistCategoryException();
+        }
+    }
+
     private void checkIsExistCategory(CategoryRequestDto categoryRequestDto) {
-        if (categoryRepository.findByName(categoryRequestDto.categoryName()).isPresent()) {
+        if (categoryRepository.existsByName(categoryRequestDto.categoryName())) {
             log.info("already exist category : {}", categoryRequestDto.categoryName());
             throw new AlreadyExistCategoryException();
         }

--- a/product/src/main/java/com/sparta/product/domain/core/Category.java
+++ b/product/src/main/java/com/sparta/product/domain/core/Category.java
@@ -1,6 +1,7 @@
 package com.sparta.product.domain.core;
 
 import com.sparta.product.application.dtos.category.CategoryRequestDto;
+import com.sparta.product.application.dtos.category.CategoryUpdateRequestDto;
 import com.sparta.product.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -35,5 +36,15 @@ public class Category extends BaseEntity {
         return Category.builder()
                 .name(categoryRequestDto.categoryName())
                 .build();
+    }
+
+    public void updateFrom(CategoryUpdateRequestDto categoryUpdateRequestDto) {
+        if (categoryUpdateRequestDto.categoryName() != null) {
+            name = categoryUpdateRequestDto.categoryName();
+        }
+
+        if (categoryUpdateRequestDto.isPublic() != null) {
+            super.updateIsPublic(categoryUpdateRequestDto.isPublic());
+        }
     }
 }

--- a/product/src/main/java/com/sparta/product/domain/repository/CategoryRepository.java
+++ b/product/src/main/java/com/sparta/product/domain/repository/CategoryRepository.java
@@ -15,4 +15,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long>, Custo
 
 //    @Query("select c from Category c where c.id in :categoryIds And c.isDeleted = false")
     List<Category> findAllByIdInAndIsDeletedFalse(@Param("categoryIds") List<Long> categoryIds);
+
+    Optional<Category> findByIdAndIsDeletedFalseAndIsPublicTrue(Long id);
+
+    Boolean existsByName(String name);
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
@@ -2,22 +2,46 @@ package com.sparta.product.presentation.controller;
 
 import com.sparta.product.application.dtos.Response;
 import com.sparta.product.application.dtos.category.CategoryRequestDto;
+import com.sparta.product.application.dtos.category.CategoryResponseDto;
+import com.sparta.product.application.dtos.category.CategoryUpdateRequestDto;
 import com.sparta.product.application.service.CategoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/products")
+@RequestMapping("/products/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @PostMapping("/categories")
+    @PostMapping
     public Response<Void> createCategory(@RequestBody @Valid CategoryRequestDto categoryRequestDto,
                                          @RequestHeader(name = "X-UserId", required = false) String userId,
                                          @RequestHeader(name = "X-Role") String role) {
         return categoryService.createCategory(categoryRequestDto, role);
+    }
+
+    @GetMapping("/{categoryId}")
+    public Response<CategoryResponseDto> getCategory(@PathVariable Long categoryId,
+                                                     @RequestHeader(name = "X-UserId", required = false) String userId,
+                                                     @RequestHeader(name = "X-Role") String role) {
+        return categoryService.getCategory(categoryId, role);
+    }
+
+    @PatchMapping("/{categoryId}")
+    public Response<Void> updateCategory(@PathVariable Long categoryId,
+                                         @RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto,
+                                         @RequestHeader(name = "X-UserId", required = false) String userId,
+                                         @RequestHeader(name = "X-Role") String role) {
+        return categoryService.updateCategory(categoryId, role, categoryUpdateRequestDto);
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public Response<Void> softDeleteCategory(@PathVariable Long categoryId,
+                                             @RequestHeader(name = "X-UserId", required = false) String userId,
+                                             @RequestHeader(name = "X-Role") String role) {
+        return categoryService.softDeleteCategory(categoryId, role);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #26

## 📝 Description

- CategoryUpdateRequestDto 생성
- 단건 조회, 수정, 삭제 API db/postman test 확인

## 💬 To Reivewers

- 코드 개선 부분이 보이시면 언제든 말씀해주세요!