### PR TITLE
refactor #48 : product service 리뷰 바탕으로 코드 수정

### DIFF
--- a/product/src/main/java/com/sparta/product/application/dtos/Response.java
+++ b/product/src/main/java/com/sparta/product/application/dtos/Response.java
@@ -1,4 +1,4 @@
-package com.sparta.product.presentation;
+package com.sparta.product.application.dtos;
 
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/product/src/main/java/com/sparta/product/application/dtos/category/CategoryResponseDto.java
+++ b/product/src/main/java/com/sparta/product/application/dtos/category/CategoryResponseDto.java
@@ -18,11 +18,12 @@ public record CategoryResponseDto(
         @JsonProperty("updated_at") LocalDateTime updatedAt
 ) {
 
+    // TODO : 추후 dto 분리 고려 예정
     public static CategoryResponseDto forUserOrSellerFrom(Category category) {
-        return new CategoryResponseDto(
-                category.getId(),
-                category.getName()
-        );
+        return CategoryResponseDto.builder()
+                .categoryId(category.getId())
+                .categoryName(category.getName())
+                .build();
     }
 
     public static CategoryResponseDto forMasterFrom(Category category) {
@@ -36,7 +37,4 @@ public record CategoryResponseDto(
         );
     }
 
-    public CategoryResponseDto(Long categoryId, String categoryName) {
-        this(categoryId, categoryName, null, null, null, null);
-    }
 }

--- a/product/src/main/java/com/sparta/product/application/dtos/product/ProductResponseDto.java
+++ b/product/src/main/java/com/sparta/product/application/dtos/product/ProductResponseDto.java
@@ -5,10 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sparta.product.application.dtos.productCategory.ProductCategoryResponseDto;
 import com.sparta.product.domain.core.Category;
 import com.sparta.product.domain.core.Product;
+import com.sparta.product.domain.core.ProductCategory;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ProductResponseDto(
         @JsonProperty("product_id") Long productId,
@@ -22,19 +25,30 @@ public record ProductResponseDto(
         @JsonProperty("updated_at") LocalDateTime updatedAt
         ) {
 
-    public static ProductResponseDto forUserOrSellerOf(Product product, List<Category> categories) {
-        return new ProductResponseDto(
-                product.getId(),
-                categories.stream()
+    // TODO : 추후 dto 분리 고려 예정
+    public static ProductResponseDto forUserOrSellerOf(List<ProductCategory> productCategories) {
+        Product product = productCategories.get(0).getProduct();
+        List<Category> categories = productCategories.stream()
+                .map(ProductCategory::getCategory)
+                .toList();
+
+        return ProductResponseDto.builder()
+                .productId(product.getId())
+                .productCategoryList(categories.stream()
                         .map(ProductCategoryResponseDto::from)
-                        .toList(),
-                product.getName(),
-                product.getPrice(),
-                product.getStock()
-        );
+                        .toList())
+                .productName(product.getName())
+                .price(product.getPrice())
+                .stock(product.getStock())
+                .build();
     }
 
-    public static ProductResponseDto forMasterOf(Product product, List<Category> categories) {
+    public static ProductResponseDto forMasterOf(List<ProductCategory> productCategories) {
+        Product product = productCategories.get(0).getProduct();
+        List<Category> categories = productCategories.stream()
+                .map(ProductCategory::getCategory)
+                .toList();
+
         return new ProductResponseDto(
                 product.getId(),
                 categories.stream()
@@ -48,9 +62,5 @@ public record ProductResponseDto(
                 product.getCreatedAt(),
                 product.getUpdatedAt()
         );
-    }
-
-    private ProductResponseDto(Long productId, List<ProductCategoryResponseDto> categories, String productName, Integer price, Integer stock) {
-        this(productId, categories, productName, price, stock, null, null, null, null);
     }
 }

--- a/product/src/main/java/com/sparta/product/application/exception/category/AlreadyExistCategoryException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/category/AlreadyExistCategoryException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.category;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class AlreadyExistCategoryException extends CategoryException {
     public AlreadyExistCategoryException() {
         super(Error.ALREADY_EXIST_CATEGORY, HttpStatus.CONFLICT);

--- a/product/src/main/java/com/sparta/product/application/exception/category/NotFoundCategoryException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/category/NotFoundCategoryException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.category;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundCategoryException extends CategoryException {
     public NotFoundCategoryException() {
         super(Error.NOT_FOUND_CATEGORY, HttpStatus.NOT_FOUND);

--- a/product/src/main/java/com/sparta/product/application/exception/common/Error.java
+++ b/product/src/main/java/com/sparta/product/application/exception/common/Error.java
@@ -18,12 +18,6 @@ public enum Error {
     NOT_FOUND_WISHLIST(1006, "해당 위시리스트를 찾을 수 없습니다."),
     QUANTITY_NOT_ENOUGH(1007, "수량은 1개 이상이어야 합니다."),
 
-    NOT_FOUND_PRODUCT(2000, "해당 상품을 찾을 수 없습니다."),
-    IS_NOT_SALE_PRODUCT(2001, "판매 중인 상품이 아닙니다."),
-    NOT_CORRECT_CATEGORY(2002, "정확한 카테고리를 입력해주세요."),
-    ALREADY_EXIST_CATEGORY(2003, "이미 존재하는 카테고리입니다."),
-    NOT_FOUND_CATEGORY(2004, "존재하지 않는 카테고리입니다."),
-
     NOT_FOUND_ORDER(3000, "해당 주문을 찾을 수 없습니다."),
     OUT_OF_STOCK(3001, "재고가 부족합니다."),
     ALREADY_SHIPPING(3002, "이미 배송 중인 상품입니다."),
@@ -31,21 +25,29 @@ public enum Error {
     ORDER_BEEN_CANCELED(3004, "주문이 취소되었습니다."),
     BEFORE_PURCHASE_TIME(3005, "구매 가능 시간이 아닙니다."),
 
-    NOT_FOUND_PRODUCTCATEGORY(7000, "상품이나 카테고리를 찾을 수 없습니다. 정상적인 상태인지 확인해주세요."),
-    TIMESALE_QUANTITY_EXCEED_PRODUCT_STOCK(8000, "상품의 보유 수량을 초과하였습니다."),
-    NOT_FOUND_TIMESALE_PRODUCT(8001, "해당 타임세일 상품을 찾을 수 없습니다."),
-    NOT_FOUND_ON_TIMESALE_PRODUCT(8002, "진행 중인 타임세일 상품이 아닙니다."),
-    EXCEED_TIMESALE_QUANTITY(8002, "남은 타임세일 재고 수량을 초과하였습니다."),
-    INVALID_TIMESALE_START_TIME(8100, "시작 시간은 현재 시간 이후여야 합니다."),
-    INVALID_TIMESALE_END_TIME(8101, "종료 시간은 시작 시간 이후여야 합니다."),
+    NOT_FOUND_PRODUCT(5000, "해당 상품을 찾을 수 없습니다."),
+    IS_NOT_SALE_PRODUCT(5001, "판매 중인 상품이 아닙니다."),
 
-    TIMESALE_SCHEDULE_ERROR(9001, "타임세일 스케줄링 중 오류가 발생했습니다."),
+    NOT_FOUND_PRODUCTCATEGORY(5050, "상품이나 카테고리를 찾을 수 없습니다. 정상적인 상태인지 확인해주세요."),
 
-    METHOD_ARGUMENT_NOT_VALID(9997, "유효하지 않은 값입니다."),
-    FORBIDDEN(9998, "접근 권한이 없습니다."),
+    ALREADY_EXIST_CATEGORY(6000, "이미 존재하는 카테고리입니다."),
+    NOT_FOUND_CATEGORY(6001, "존재하지 않는 카테고리입니다."),
+    NOT_CORRECT_CATEGORY(6300, "정확한 카테고리를 입력해주세요."),
+
+    NOT_FOUND_TIMESALE_PRODUCT(7000, "해당 타임세일 상품을 찾을 수 없습니다."),
+    NOT_FOUND_ON_TIMESALE_PRODUCT(7001, "진행 중인 타임세일 상품이 아닙니다."),
+    INVALID_TIMESALE_START_TIME(7100, "시작 시간은 현재 시간 이후여야 합니다."),
+    INVALID_TIMESALE_END_TIME(7101, "종료 시간은 시작 시간 이후여야 합니다."),
+    TIMESALE_QUANTITY_EXCEED_PRODUCT_STOCK(7300, "상품의 보유 수량을 초과하였습니다."),
+    EXCEED_TIMESALE_QUANTITY(7301, "남은 타임세일 재고 수량을 초과하였습니다."),
+    TIMESALE_SCHEDULE_ERROR(7500, "타임세일 스케줄링 중 오류가 발생했습니다."),
+
     INTERNAL_SERVER_ERROR(9999, "서버 오류입니다."),
     CIRCUIT_BREAKER_OPEN(10000, "이용량 증가로 현재 서비스가 불가능합니다."),
-    SERVER_TIMEOUT(10001, "응답 시간을 초과하였습니다.");
+    SERVER_TIMEOUT(10001, "응답 시간을 초과하였습니다."),
+
+    METHOD_ARGUMENT_NOT_VALID(20000, "유효하지 않은 값입니다."),
+    FORBIDDEN(20001, "접근 권한이 없습니다.");
 
     Integer code;
     String message;

--- a/product/src/main/java/com/sparta/product/application/exception/common/ForbiddenRoleException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/common/ForbiddenRoleException.java
@@ -1,7 +1,9 @@
 package com.sparta.product.application.exception.common;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.FORBIDDEN)
 public class ForbiddenRoleException extends ForbiddenException{
     public ForbiddenRoleException(){
         super(Error.FORBIDDEN, HttpStatus.FORBIDDEN);

--- a/product/src/main/java/com/sparta/product/application/exception/product/NotFoundProductException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/product/NotFoundProductException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.product;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundProductException extends ProductException{
     public NotFoundProductException() {
         super(Error.NOT_FOUND_PRODUCT, HttpStatus.NOT_FOUND);

--- a/product/src/main/java/com/sparta/product/application/exception/productCategory/NotFoundProductCategoryException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/productCategory/NotFoundProductCategoryException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.productCategory;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundProductCategoryException extends ProductCategoryException {
     public NotFoundProductCategoryException() {
         super(Error.NOT_FOUND_PRODUCTCATEGORY, HttpStatus.NOT_FOUND);

--- a/product/src/main/java/com/sparta/product/application/exception/scheduler/TimeSaleScheduleException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/scheduler/TimeSaleScheduleException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.scheduler;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 public class TimeSaleScheduleException extends ScheduleException {
     public TimeSaleScheduleException() {
         super(Error.TIMESALE_SCHEDULE_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/ExceedTimeSaleQuantityException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/ExceedTimeSaleQuantityException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.timesale;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class ExceedTimeSaleQuantityException extends TimeSaleException {
     public ExceedTimeSaleQuantityException() {
         super(Error.EXCEED_TIMESALE_QUANTITY, HttpStatus.BAD_REQUEST);

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/InvalidTimeSaleEndTimeException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/InvalidTimeSaleEndTimeException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.timesale;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class InvalidTimeSaleEndTimeException extends TimeSaleException {
     public InvalidTimeSaleEndTimeException() {
         super(Error.INVALID_TIMESALE_END_TIME, HttpStatus.BAD_REQUEST);

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/InvalidTimeSaleStartTimeException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/InvalidTimeSaleStartTimeException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.timesale;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class InvalidTimeSaleStartTimeException extends TimeSaleException {
     public InvalidTimeSaleStartTimeException() {
         super(Error.INVALID_TIMESALE_START_TIME, HttpStatus.BAD_REQUEST);

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/NotFoundOnTimeSaleException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/NotFoundOnTimeSaleException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.timesale;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundOnTimeSaleException extends TimeSaleException {
     public NotFoundOnTimeSaleException() {
         super(Error.NOT_FOUND_ON_TIMESALE_PRODUCT, HttpStatus.NOT_FOUND);

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/NotFoundTimeSaleException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/NotFoundTimeSaleException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.timesale;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundTimeSaleException extends TimeSaleException {
     public NotFoundTimeSaleException() {
         super(Error.NOT_FOUND_TIMESALE_PRODUCT, HttpStatus.NOT_FOUND);

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/TimeSaleQuantityExceedProductStockException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/TimeSaleQuantityExceedProductStockException.java
@@ -2,7 +2,9 @@ package com.sparta.product.application.exception.timesale;
 
 import com.sparta.product.application.exception.common.Error;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class TimeSaleQuantityExceedProductStockException extends TimeSaleException {
     public TimeSaleQuantityExceedProductStockException() {
         super(Error.TIMESALE_QUANTITY_EXCEED_PRODUCT_STOCK, HttpStatus.BAD_REQUEST);

--- a/product/src/main/java/com/sparta/product/application/service/CategoryService.java
+++ b/product/src/main/java/com/sparta/product/application/service/CategoryService.java
@@ -8,7 +8,7 @@ import com.sparta.product.application.exception.common.ForbiddenRoleException;
 import com.sparta.product.domain.common.UserRoleEnum;
 import com.sparta.product.domain.core.Category;
 import com.sparta.product.domain.repository.CategoryRepository;
-import com.sparta.product.presentation.Response;
+import com.sparta.product.application.dtos.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,26 +23,28 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public void createCategory(String categoryName, String role) {
+    public Response<Void> createCategory(String categoryName, String role) {
         checkIsMaster(role);
         checkIsExistCategory(categoryName);
 
         categoryRepository.save(Category.createFrom(categoryName));
+        return Response.<Void>builder()
+                .code(HttpStatus.CREATED.value())
+                .message(HttpStatus.CREATED.getReasonPhrase())
+                .build();
     }
 
     @Transactional(readOnly = true)
-    public CategoryResponseDto getCategory(Long categoryId, String role) {
-        Category category = role.equals(UserRoleEnum.MASTER.toString()) ?
-                categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new)
-                : categoryRepository.findByIdAndIsDeletedFalseAndIsPublicTrue(categoryId).orElseThrow(NotFoundCategoryException::new);
-
-        return role.equals(UserRoleEnum.MASTER.toString()) ?
-                        CategoryResponseDto.forMasterFrom(category)
-                        : CategoryResponseDto.forUserOrSellerFrom(category);
+    public Response<CategoryResponseDto> getCategory(Long categoryId, String role) {
+        return Response.<CategoryResponseDto>builder()
+                .data(role.equals(UserRoleEnum.MASTER.toString()) ?
+                        CategoryResponseDto.forMasterFrom(categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new))
+                        : CategoryResponseDto.forUserOrSellerFrom(categoryRepository.findByIdAndIsDeletedFalseAndIsPublicTrue(categoryId).orElseThrow(NotFoundCategoryException::new)))
+                .build();
     }
 
     @Transactional
-    public void updateCategory(Long categoryId, String role, CategoryUpdateRequestDto categoryUpdateRequestDto) {
+    public Response<Void> updateCategory(Long categoryId, String role, CategoryUpdateRequestDto categoryUpdateRequestDto) {
         checkIsMaster(role);
         if (categoryUpdateRequestDto.categoryName() != null) {
             checkIsExistCategory(categoryUpdateRequestDto);
@@ -50,14 +52,18 @@ public class CategoryService {
 
         Category category = categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new);
         category.updateFrom(categoryUpdateRequestDto.categoryName(), categoryUpdateRequestDto.isPublic());
+
+        return Response.<Void>builder().build();
     }
 
     @Transactional
-    public void softDeleteCategory(Long categoryId, String role) {
+    public Response<Void> softDeleteCategory(Long categoryId, String role) {
         checkIsMaster(role);
 
         Category category = categoryRepository.findById(categoryId).orElseThrow(NotFoundCategoryException::new);
         category.updateIsDeleted(true);
+
+        return Response.<Void>builder().build();
     }
 
     private void checkIsExistCategory(CategoryUpdateRequestDto categoryUpdateRequestDto) {

--- a/product/src/main/java/com/sparta/product/application/service/TimeSaleService.java
+++ b/product/src/main/java/com/sparta/product/application/service/TimeSaleService.java
@@ -13,14 +13,13 @@ import com.sparta.product.domain.repository.TimeSaleProductRepository;
 import com.sparta.product.application.service.redis.RedisKeys;
 import com.sparta.product.application.service.redis.TimeSaleRedisManager;
 import com.sparta.product.domain.repository.TimeSaleSoldOutRepository;
-import com.sparta.product.presentation.Response;
+import com.sparta.product.application.dtos.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -38,7 +37,7 @@ public class TimeSaleService {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public void createTimeSaleProduct(TimeSaleProductRequestDto timeSaleProductRequestDto, String role) {
+    public Response<Void> createTimeSaleProduct(TimeSaleProductRequestDto timeSaleProductRequestDto, String role) {
         checkIsMaster(role);
 
         Long productId = timeSaleProductRequestDto.productId();
@@ -55,6 +54,11 @@ public class TimeSaleService {
         timeSaleProductRepository.save(timeSaleProduct);
 
         redisManager.scheduleTimeSale(timeSaleProduct);
+
+        return Response.<Void>builder()
+                .code(HttpStatus.CREATED.value())
+                .message(HttpStatus.CREATED.getReasonPhrase())
+                .build();
     }
 
     private void validateTimeSaleRequest(TimeSaleProductRequestDto request, Product product) {

--- a/product/src/main/java/com/sparta/product/application/service/TimeSaleService.java
+++ b/product/src/main/java/com/sparta/product/application/service/TimeSaleService.java
@@ -38,7 +38,7 @@ public class TimeSaleService {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public Response<Void> createTimeSaleProduct(TimeSaleProductRequestDto timeSaleProductRequestDto, String role) {
+    public void createTimeSaleProduct(TimeSaleProductRequestDto timeSaleProductRequestDto, String role) {
         checkIsMaster(role);
 
         Long productId = timeSaleProductRequestDto.productId();
@@ -55,11 +55,6 @@ public class TimeSaleService {
         timeSaleProductRepository.save(timeSaleProduct);
 
         redisManager.scheduleTimeSale(timeSaleProduct);
-
-        return Response.<Void>builder()
-                .code(HttpStatus.CREATED.value())
-                .message(HttpStatus.CREATED.getReasonPhrase())
-                .build();
     }
 
     private void validateTimeSaleRequest(TimeSaleProductRequestDto request, Product product) {

--- a/product/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
@@ -3,10 +3,8 @@ package com.sparta.product.presentation.controller;
 import com.sparta.product.application.dtos.category.CategoryResponseDto;
 import com.sparta.product.application.dtos.category.CategoryUpdateRequestDto;
 import com.sparta.product.application.service.CategoryService;
-import com.sparta.product.domain.common.UserRoleEnum;
-import com.sparta.product.presentation.Response;
+import com.sparta.product.application.dtos.Response;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,20 +18,14 @@ public class CategoryController {
     public Response<Void> createCategory(@RequestBody String categoryName,
                                          @RequestHeader(name = "X-UserId", required = false) String userId,
                                          @RequestHeader(name = "X-Role") String role) {
-        categoryService.createCategory(categoryName, role);
-        return Response.<Void>builder()
-                .code(HttpStatus.CREATED.value())
-                .message(HttpStatus.CREATED.getReasonPhrase())
-                .build();
+        return categoryService.createCategory(categoryName, role);
     }
 
     @GetMapping("/{categoryId}")
     public Response<CategoryResponseDto> getCategory(@PathVariable Long categoryId,
                                                      @RequestHeader(name = "X-UserId", required = false) String userId,
                                                      @RequestHeader(name = "X-Role") String role) {
-        return Response.<CategoryResponseDto>builder()
-                .data(categoryService.getCategory(categoryId, role))
-                .build();
+        return categoryService.getCategory(categoryId, role);
     }
 
     @PatchMapping("/{categoryId}")
@@ -41,16 +33,13 @@ public class CategoryController {
                                          @RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto,
                                          @RequestHeader(name = "X-UserId", required = false) String userId,
                                          @RequestHeader(name = "X-Role") String role) {
-        categoryService.updateCategory(categoryId, role, categoryUpdateRequestDto);
-        return Response.<Void>builder().build();
+        return categoryService.updateCategory(categoryId, role, categoryUpdateRequestDto);
     }
 
     @DeleteMapping("/{categoryId}")
     public Response<Void> softDeleteCategory(@PathVariable Long categoryId,
                                              @RequestHeader(name = "X-UserId", required = false) String userId,
                                              @RequestHeader(name = "X-Role") String role) {
-        categoryService.softDeleteCategory(categoryId, role);
-        return Response.<Void>builder().build();
-
+        return categoryService.softDeleteCategory(categoryId, role);
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
@@ -3,8 +3,10 @@ package com.sparta.product.presentation.controller;
 import com.sparta.product.application.dtos.category.CategoryResponseDto;
 import com.sparta.product.application.dtos.category.CategoryUpdateRequestDto;
 import com.sparta.product.application.service.CategoryService;
+import com.sparta.product.domain.common.UserRoleEnum;
 import com.sparta.product.presentation.Response;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,14 +20,20 @@ public class CategoryController {
     public Response<Void> createCategory(@RequestBody String categoryName,
                                          @RequestHeader(name = "X-UserId", required = false) String userId,
                                          @RequestHeader(name = "X-Role") String role) {
-        return categoryService.createCategory(categoryName, role);
+        categoryService.createCategory(categoryName, role);
+        return Response.<Void>builder()
+                .code(HttpStatus.CREATED.value())
+                .message(HttpStatus.CREATED.getReasonPhrase())
+                .build();
     }
 
     @GetMapping("/{categoryId}")
     public Response<CategoryResponseDto> getCategory(@PathVariable Long categoryId,
                                                      @RequestHeader(name = "X-UserId", required = false) String userId,
                                                      @RequestHeader(name = "X-Role") String role) {
-        return categoryService.getCategory(categoryId, role);
+        return Response.<CategoryResponseDto>builder()
+                .data(categoryService.getCategory(categoryId, role))
+                .build();
     }
 
     @PatchMapping("/{categoryId}")
@@ -33,13 +41,16 @@ public class CategoryController {
                                          @RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto,
                                          @RequestHeader(name = "X-UserId", required = false) String userId,
                                          @RequestHeader(name = "X-Role") String role) {
-        return categoryService.updateCategory(categoryId, role, categoryUpdateRequestDto);
+        categoryService.updateCategory(categoryId, role, categoryUpdateRequestDto);
+        return Response.<Void>builder().build();
     }
 
     @DeleteMapping("/{categoryId}")
     public Response<Void> softDeleteCategory(@PathVariable Long categoryId,
                                              @RequestHeader(name = "X-UserId", required = false) String userId,
                                              @RequestHeader(name = "X-Role") String role) {
-        return categoryService.softDeleteCategory(categoryId, role);
+        categoryService.softDeleteCategory(categoryId, role);
+        return Response.<Void>builder().build();
+
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.sparta.product.presentation.controller;
 
+import com.sparta.product.domain.common.UserRoleEnum;
 import com.sparta.product.presentation.Response;
 import com.sparta.product.application.dtos.product.ProductRequestDto;
 import com.sparta.product.application.dtos.product.ProductResponseDto;
@@ -7,6 +8,7 @@ import com.sparta.product.application.dtos.product.ProductUpdateRequestDto;
 import com.sparta.product.application.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,14 +22,20 @@ public class ProductController {
     public Response<Void> createProduct(@RequestBody @Valid ProductRequestDto productRequestDto,
                                         @RequestHeader(name = "X-UserId", required = false) String userId,
                                         @RequestHeader(name = "X-Role") String role) {
-        return productService.createProduct(productRequestDto, role);
+        productService.createProduct(productRequestDto, role);
+        return Response.<Void>builder()
+                .code(HttpStatus.CREATED.value())
+                .message(HttpStatus.CREATED.getReasonPhrase())
+                .build();
     }
 
     @GetMapping("/{productId}")
     public Response<ProductResponseDto> getProduct(@PathVariable Long productId,
                                                    @RequestHeader(name = "X-UserId", required = false) String userId,
                                                    @RequestHeader(name = "X-Role") String role) {
-        return productService.getProduct(productId, role);
+        return Response.<ProductResponseDto>builder()
+                .data(productService.getProduct(productId, role))
+                .build();
     }
 
     @PatchMapping("/{productId}")
@@ -35,13 +43,15 @@ public class ProductController {
                                         @RequestBody @Valid ProductUpdateRequestDto productUpdateRequestDto,
                                         @RequestHeader(name = "X-UserId", required = false) String userId,
                                         @RequestHeader(name = "X-Role") String role) {
-        return productService.updateProduct(productId, role, productUpdateRequestDto);
+        productService.updateProduct(productId, role, productUpdateRequestDto);
+        return Response.<Void>builder().build();
     }
 
     @DeleteMapping("/{productId}")
     public Response<Void> softDeleteProduct(@PathVariable Long productId,
                                             @RequestHeader(name = "X-UserId", required = false) String userId,
                                             @RequestHeader(name = "X-Role") String role) {
-        return productService.softDeleteProduct(productId, role);
+        productService.softDeleteProduct(productId, role);
+        return Response.<Void>builder().build();
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/ProductController.java
@@ -1,14 +1,12 @@
 package com.sparta.product.presentation.controller;
 
-import com.sparta.product.domain.common.UserRoleEnum;
-import com.sparta.product.presentation.Response;
+import com.sparta.product.application.dtos.Response;
 import com.sparta.product.application.dtos.product.ProductRequestDto;
 import com.sparta.product.application.dtos.product.ProductResponseDto;
 import com.sparta.product.application.dtos.product.ProductUpdateRequestDto;
 import com.sparta.product.application.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,20 +20,14 @@ public class ProductController {
     public Response<Void> createProduct(@RequestBody @Valid ProductRequestDto productRequestDto,
                                         @RequestHeader(name = "X-UserId", required = false) String userId,
                                         @RequestHeader(name = "X-Role") String role) {
-        productService.createProduct(productRequestDto, role);
-        return Response.<Void>builder()
-                .code(HttpStatus.CREATED.value())
-                .message(HttpStatus.CREATED.getReasonPhrase())
-                .build();
+        return productService.createProduct(productRequestDto, role);
     }
 
     @GetMapping("/{productId}")
     public Response<ProductResponseDto> getProduct(@PathVariable Long productId,
                                                    @RequestHeader(name = "X-UserId", required = false) String userId,
                                                    @RequestHeader(name = "X-Role") String role) {
-        return Response.<ProductResponseDto>builder()
-                .data(productService.getProduct(productId, role))
-                .build();
+        return productService.getProduct(productId, role);
     }
 
     @PatchMapping("/{productId}")
@@ -43,15 +35,13 @@ public class ProductController {
                                         @RequestBody @Valid ProductUpdateRequestDto productUpdateRequestDto,
                                         @RequestHeader(name = "X-UserId", required = false) String userId,
                                         @RequestHeader(name = "X-Role") String role) {
-        productService.updateProduct(productId, role, productUpdateRequestDto);
-        return Response.<Void>builder().build();
+        return productService.updateProduct(productId, role, productUpdateRequestDto);
     }
 
     @DeleteMapping("/{productId}")
     public Response<Void> softDeleteProduct(@PathVariable Long productId,
                                             @RequestHeader(name = "X-UserId", required = false) String userId,
                                             @RequestHeader(name = "X-Role") String role) {
-        productService.softDeleteProduct(productId, role);
-        return Response.<Void>builder().build();
+        return productService.softDeleteProduct(productId, role);
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/TimeSaleController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/TimeSaleController.java
@@ -2,11 +2,10 @@ package com.sparta.product.presentation.controller;
 
 import com.sparta.product.application.dtos.timesale.TimeSaleProductRequestDto;
 import com.sparta.product.application.service.TimeSaleService;
-import com.sparta.product.presentation.Response;
+import com.sparta.product.application.dtos.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -21,10 +20,6 @@ public class TimeSaleController {
     public Response<Void> createTimeSaleProduct(@RequestBody @Valid TimeSaleProductRequestDto timeSaleProductRequestDto,
                                                 @RequestHeader(name = "X-UserId", required = false) String userId,
                                                 @RequestHeader(name = "X-Role") String role) {
-        timeSaleService.createTimeSaleProduct(timeSaleProductRequestDto, role);
-        return Response.<Void>builder()
-                .code(HttpStatus.CREATED.value())
-                .message(HttpStatus.CREATED.getReasonPhrase())
-                .build();
+        return timeSaleService.createTimeSaleProduct(timeSaleProductRequestDto, role);
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/TimeSaleController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/TimeSaleController.java
@@ -6,6 +6,7 @@ import com.sparta.product.presentation.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -20,6 +21,10 @@ public class TimeSaleController {
     public Response<Void> createTimeSaleProduct(@RequestBody @Valid TimeSaleProductRequestDto timeSaleProductRequestDto,
                                                 @RequestHeader(name = "X-UserId", required = false) String userId,
                                                 @RequestHeader(name = "X-Role") String role) {
-        return timeSaleService.createTimeSaleProduct(timeSaleProductRequestDto, role);
+        timeSaleService.createTimeSaleProduct(timeSaleProductRequestDto, role);
+        return Response.<Void>builder()
+                .code(HttpStatus.CREATED.value())
+                .message(HttpStatus.CREATED.getReasonPhrase())
+                .build();
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/handler/CommonExceptionHandler.java
+++ b/product/src/main/java/com/sparta/product/presentation/handler/CommonExceptionHandler.java
@@ -20,6 +20,7 @@ import java.util.Map;
 @RestControllerAdvice(basePackages = {"com.sparta.product.presentation.controller"})
 public class CommonExceptionHandler {
 
+
     @ExceptionHandler(ProductException.class)
     public Response<Void> ProductExceptionHandler(ProductException e) {
 
@@ -51,6 +52,7 @@ public class CommonExceptionHandler {
                 .build();
     }
 
+    // global error 경우가 있을 수 있으니 예외 처리가 이상하게 나오면 확인 필요
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public Response<Void> MethodArgumentNotValidHandler(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();

--- a/product/src/main/java/com/sparta/product/presentation/handler/CommonExceptionHandler.java
+++ b/product/src/main/java/com/sparta/product/presentation/handler/CommonExceptionHandler.java
@@ -3,7 +3,7 @@ package com.sparta.product.presentation.handler;
 import com.sparta.product.application.exception.productCategory.ProductCategoryException;
 import com.sparta.product.application.exception.timesale.TimeSaleException;
 import com.sparta.product.application.exception.scheduler.ScheduleException;
-import com.sparta.product.presentation.Response;
+import com.sparta.product.application.dtos.Response;
 import com.sparta.product.application.exception.category.CategoryException;
 import com.sparta.product.application.exception.common.Error;
 import com.sparta.product.application.exception.common.ForbiddenException;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #48

## 📝 Description

- dto 컴팩트 생성자 null 값 불합리 판단 -> builer로 진행. 추후 dto 분리 고려 예정
- exception에 @HttpSatusCode추가 설정.
- 각 예외 클래스에 알맞은 @ResponseStatus 추가
- error enum 서비별로 맞게 수정
- getProduct에서 productCategories를 가공하는 로직을 dto 내부에서 하도록 수정
- service 응답을 Response를 사용하지 않도록 변경 -> controller에서 응답처리

- 추후 서킷브레이커 추가 등의 기능 추가 시 service에서 Response를 처리하는게 좋을 것 같다는 판단으로 controller와 service 응답 재수정.

## 💬 To Reivewers

- 개선 사항이 보이면 리뷰 남겨주세요!