### PR TITLE
[#73] feat : Order RedLock

### DIFF
--- a/order/build.gradle.kts
+++ b/order/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("org.springframework.kafka:spring-kafka")
 	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+	implementation("org.redisson:redisson-spring-boot-starter:3.42.0")
 
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/order/src/main/kotlin/com/study/order/application/dto/event/provider/ProductStockAdjustmentEvent.kt
+++ b/order/src/main/kotlin/com/study/order/application/dto/event/provider/ProductStockAdjustmentEvent.kt
@@ -1,8 +1,0 @@
-package com.study.order.application.dto.event.provider
-
-
-data class ProductStockAdjustmentEvent(
-    val productId: Long,
-    val quantity: Int,
-    val isDecrement: Boolean,
-)

--- a/order/src/main/kotlin/com/study/order/application/dto/response/ProductResponseDto.kt
+++ b/order/src/main/kotlin/com/study/order/application/dto/response/ProductResponseDto.kt
@@ -11,4 +11,17 @@ data class ProductResponseDto(
     val price: Int,
     @JsonProperty("stock")
     val stock: Int,
-)
+    val isTimeSale: Boolean
+) {
+    companion object {
+        fun from(record: ProductData, isTimeSale: Boolean): ProductResponseDto {
+            return ProductResponseDto(
+                record.productId.toLong(),
+                record.name,
+                record.price.toInt(),
+                record.stock.toInt(),
+                isTimeSale
+            )
+        }
+    }
+}

--- a/order/src/main/kotlin/com/study/order/application/exception/Error.kt
+++ b/order/src/main/kotlin/com/study/order/application/exception/Error.kt
@@ -15,4 +15,7 @@ enum class Error(val status: Int, val message: String) {
     NOT_FOUND_PRODUCT(5000, "상품을 찾을 수 없습니다."),
     NOT_ENOUGH_STOCK(5200, "재고가 부족합니다."),
 
+    ACQUIRE_LOCK_TIMEOUT(99999, "락 획득에 실패했습니다."),
+
+    INTERNAL_SERVER_ERROR(100000, "서버 에러입니다.")
 }

--- a/order/src/main/kotlin/com/study/order/application/exception/RedisException.kt
+++ b/order/src/main/kotlin/com/study/order/application/exception/RedisException.kt
@@ -1,0 +1,12 @@
+package com.study.order.application.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+open class RedisException(val error: Error) : RuntimeException()
+
+@ResponseStatus(HttpStatus.REQUEST_TIMEOUT)
+class AcquireLockTimeoutException : RedisException(Error.ACQUIRE_LOCK_TIMEOUT)
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+class InternalServerError : RedisException(Error.INTERNAL_SERVER_ERROR)

--- a/order/src/main/kotlin/com/study/order/application/service/CacheService.kt
+++ b/order/src/main/kotlin/com/study/order/application/service/CacheService.kt
@@ -6,10 +6,15 @@ interface CacheService {
 
     suspend fun getProductInfo(productId: Long): ProductResponseDto?
 
-    suspend fun increment(productId: Long, quantity: Int)
+    suspend fun decrementStock(productId: Long, amount: Int, isTimeSale: Boolean)
 
-    suspend fun decrement(productId: Long, quantity: Int)
+    suspend fun incrementStock(productId: Long, amount: Int, isTimeSale: Boolean)
 
-    suspend fun getSoldQuantity(productId: Long): Int?
+    suspend fun executeWithLock(productIds: List<Long>, runner: suspend () -> Unit)
 
+    suspend fun saveOrderInfo(productId: Long, isTimeSale: Boolean)
+
+    suspend fun isTimeSaleOrder(productId: Long): Boolean
+
+    suspend fun deleteOrderInfo(productId: Long, isTimeSale: Boolean)
 }

--- a/order/src/main/kotlin/com/study/order/application/service/OrderService.kt
+++ b/order/src/main/kotlin/com/study/order/application/service/OrderService.kt
@@ -103,6 +103,7 @@ class OrderService(
         } else {
             orderDetails.map {
                 cacheService.decrementStock(it.productId, it.quantity, cacheService.isTimeSaleOrder(it.productId))
+                cacheService.deleteOrderInfo(it.productId, cacheService.isTimeSaleOrder(it.productId))
             }
             order.updateStatus(PAYMENT_FAILED)
         }

--- a/order/src/main/kotlin/com/study/order/domain/model/Order.kt
+++ b/order/src/main/kotlin/com/study/order/domain/model/Order.kt
@@ -11,7 +11,7 @@ class Order (
     @Id
     val id: Long = 0,
     val userId: Long,
-    val pgOrderId: String? = null,
+    val pgOrderId: String,
     val totalPrice: Int = 0,
     val paymentPrice: Int = 0,
     val pointAmount: Int = 0,

--- a/order/src/main/kotlin/com/study/order/infrastructure/cache/CacheService.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/cache/CacheService.kt
@@ -3,24 +3,43 @@ package com.study.order.infrastructure.cache
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.study.order.application.dto.response.ProductData
 import com.study.order.application.dto.response.ProductResponseDto
+import com.study.order.application.exception.AcquireLockTimeoutException
+import com.study.order.application.exception.InternalServerError
 import com.study.order.application.service.CacheService
+import com.study.order.infrastructure.config.log.KEY_TXID
 import com.study.order.infrastructure.config.log.LoggerProvider
+import com.study.order.infrastructure.utils.TransactionHelper
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.withContext
+import org.redisson.api.RedissonReactiveClient
+import org.slf4j.MDC
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.stereotype.Service
-
-private const val PRODUCT_KEY = "product:"
-private const val TIME_SALE_KEY = "timeSale:"
-private const val PRODUCT_ORDER_KEY = "product:order:"
-private const val TIME_SALE_ORDER_KEY = "timeSale:order:"
+import java.util.concurrent.TimeUnit
 
 @Service
 class CacheService(
-    redisTemplate: ReactiveRedisTemplate<String, String>,
     private val mapper: ObjectMapper,
+    private val transactionHelper: TransactionHelper,
+    private val redissonClient: RedissonReactiveClient,
+    redisTemplate: ReactiveRedisTemplate<String, String>,
 ) : CacheService {
+
+    companion object {
+        private const val PRODUCT_KEY = "product:"
+        private const val TIME_SALE_KEY = "timeSale:"
+        private const val REDISSON_KEY_PREFIX = "lock_"
+        private const val PRODUCT_STOCK_KEY = "stock"
+        private const val ORDER_KEY = "order:"
+        private const val TRY_LOCK_TIME_OUT = 5L
+        private const val LEASE_TIME = 4L
+        private const val TARGET_METHOD_TIME_OUT = 3L
+    }
 
     private val logger = LoggerProvider.logger
     private val opsForValue = redisTemplate.opsForValue()
@@ -30,17 +49,57 @@ class CacheService(
         return getHash(productId)
     }
 
-    override suspend fun increment(productId: Long, quantity: Int) {
-        opsForValue.increment(TIME_SALE_ORDER_KEY + productId, quantity.toLong()).awaitSingleOrNull()
+    override suspend fun decrementStock(productId: Long, amount: Int, isTimeSale: Boolean) {
+        updateStock(productId, amount, false, isTimeSale)
     }
 
-    override suspend fun decrement(productId: Long, quantity: Int) {
-        opsForValue.decrement(TIME_SALE_ORDER_KEY + productId, quantity.toLong()).awaitSingleOrNull()
+    override suspend fun incrementStock(productId: Long, amount: Int, isTimeSale: Boolean) {
+        updateStock(productId, amount, true, isTimeSale)
     }
 
-    override suspend fun getSoldQuantity(productId: Long): Int? {
-        return opsForValue.get(TIME_SALE_ORDER_KEY + productId).awaitSingleOrNull()?.toInt()
-            ?: opsForValue.get(PRODUCT_ORDER_KEY + productId).awaitSingleOrNull()?.toInt()
+    override suspend fun executeWithLock(productIds: List<Long>, runner: suspend () -> Unit) {
+
+        val txid = MDC.get(KEY_TXID).toLong()
+        val locks = productIds.map { redissonClient.getLock(REDISSON_KEY_PREFIX + PRODUCT_KEY + it) }
+
+        try {
+            locks.forEach {
+                check(it.tryLock(TRY_LOCK_TIME_OUT, LEASE_TIME, TimeUnit.SECONDS, txid).awaitSingle()) {
+                    throw AcquireLockTimeoutException()
+                }
+            }
+
+            transactionHelper.executeInNewTransaction(TARGET_METHOD_TIME_OUT) {
+                runner()
+            }
+        } catch (ex: Exception) {
+            when (ex) {
+                is TimeoutCancellationException -> throw AcquireLockTimeoutException()
+                else -> throw InternalServerError()
+            }
+        } finally {
+            withContext(NonCancellable) {
+                locks.forEach {
+                    it.unlock(txid).awaitSingleOrNull()
+                }
+            }
+        }
+    }
+
+    override suspend fun saveOrderInfo(productId: Long, isTimeSale: Boolean) {
+        val key = ORDER_KEY + if (isTimeSale) TIME_SALE_KEY + productId else PRODUCT_KEY + productId
+
+        opsForValue.set(key, isTimeSale.toString().uppercase()).awaitSingle()
+    }
+
+    override suspend fun isTimeSaleOrder(productId: Long): Boolean {
+        return opsForValue.get(ORDER_KEY + TIME_SALE_KEY + productId).awaitSingleOrNull() != null
+    }
+
+    override suspend fun deleteOrderInfo(productId: Long, isTimeSale: Boolean) {
+        val key = ORDER_KEY + if (isTimeSale) TIME_SALE_KEY + productId else PRODUCT_KEY + productId
+
+        opsForValue.delete(key).awaitSingle()
     }
 
     private suspend fun getHash(productId: Long): ProductResponseDto? {
@@ -50,22 +109,26 @@ class CacheService(
             val entries = opsForHash.entries(key).asFlow().toList()
             if (entries.isNotEmpty()) {
                 val productData = mapper.writeValueAsString(entries.associate { it.key to it.value })
-                return convertDataAsDto(productData)
+                return convertDataAsDto(productData, key.startsWith(TIME_SALE_KEY))
             }
         }
         return null
     }
 
-    private fun convertDataAsDto(record: String): ProductResponseDto {
-        return toProductResponseDto(mapper.readValue(record, ProductData::class.java))
+    private fun convertDataAsDto(record: String, isTimeSale: Boolean): ProductResponseDto {
+        return toProductResponseDto(mapper.readValue(record, ProductData::class.java), isTimeSale)
     }
 
-    private fun toProductResponseDto(record: ProductData): ProductResponseDto {
-        return ProductResponseDto(
-            record.productId.toLong(),
-            record.name,
-            record.price.toInt(),
-            record.stock.toInt()
-        )
+    private fun toProductResponseDto(record: ProductData, isTimeSale: Boolean): ProductResponseDto {
+        return ProductResponseDto.from(record, isTimeSale)
+    }
+
+    private suspend fun updateStock(productId: Long, amount: Int, isIncrement: Boolean, isTimeSale: Boolean) {
+        val key = if (isTimeSale) TIME_SALE_KEY + productId else PRODUCT_KEY + productId
+
+        val stock = opsForHash.get(key, PRODUCT_STOCK_KEY).awaitSingle().toInt()
+        val newStock = if (isIncrement) stock + amount else stock - amount
+
+        opsForHash.put(key, PRODUCT_STOCK_KEY, newStock.toString()).awaitSingle()
     }
 }

--- a/order/src/main/kotlin/com/study/order/infrastructure/config/log/ErrorConfig.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/config/log/ErrorConfig.kt
@@ -1,6 +1,6 @@
 package com.study.order.infrastructure.config.log
 
-import com.study.order.infrastructure.extension.txid
+import com.study.order.infrastructure.utils.txid
 import org.slf4j.MDC
 import org.springframework.boot.web.error.ErrorAttributeOptions
 import org.springframework.boot.web.reactive.error.DefaultErrorAttributes

--- a/order/src/main/kotlin/com/study/order/infrastructure/config/log/MdcFilter.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/config/log/MdcFilter.kt
@@ -1,6 +1,6 @@
 package com.study.order.infrastructure.config.log
 
-import com.study.order.infrastructure.extension.txid
+import com.study.order.infrastructure.utils.txid
 import io.micrometer.context.ContextRegistry
 import org.slf4j.MDC
 import org.springframework.core.annotation.Order
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono
 import reactor.util.context.Context
 import java.util.*
 
-const val KEY_TXID = "X-UserId"
+const val KEY_TXID = "X-Id"
 
 @Order(1)
 @Component

--- a/order/src/main/kotlin/com/study/order/infrastructure/config/redis/RedisConfig.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/config/redis/RedisConfig.kt
@@ -1,0 +1,28 @@
+package com.study.order.infrastructure.config.redis
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonReactiveClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+
+@Component
+class RedisConfig(
+    @Value("\${spring.data.redis.host}")
+    private val host: String,
+    @Value("\${spring.data.redis.port}")
+    private val port: String,
+) {
+
+    @Bean
+    fun redissonClient() : RedissonReactiveClient {
+        val config = Config().apply {
+            useSingleServer().apply {
+                address = "redis://$host:$port"
+            }
+        }
+        return Redisson.create(config).reactive()
+    }
+
+}

--- a/order/src/main/kotlin/com/study/order/infrastructure/utils/QueryExtension.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/utils/QueryExtension.kt
@@ -1,4 +1,4 @@
-package com.study.order.infrastructure.extension
+package com.study.order.infrastructure.utils
 
 fun <T> T?.query(f: (T) -> String): String {
     return when {

--- a/order/src/main/kotlin/com/study/order/infrastructure/utils/ServletHttpRequestExtension.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/utils/ServletHttpRequestExtension.kt
@@ -1,4 +1,4 @@
-package com.study.order.infrastructure.extension
+package com.study.order.infrastructure.utils
 
 import org.springframework.http.server.reactive.ServerHttpRequest
 

--- a/order/src/main/kotlin/com/study/order/infrastructure/utils/TransactionHelper.kt
+++ b/order/src/main/kotlin/com/study/order/infrastructure/utils/TransactionHelper.kt
@@ -1,0 +1,26 @@
+package com.study.order.infrastructure.utils
+
+import kotlinx.coroutines.withTimeout
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+@Component
+class TransactionHelper {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    suspend fun executeInNewTransaction(timeoutSecond: Long = -1, runner: suspend () -> Unit) {
+        if (timeoutSecond == -1L) {
+            runner()
+        }
+
+        try {
+            withTimeout(timeoutSecond.toDuration(DurationUnit.SECONDS)) {
+                runner()
+            }
+        } catch (ex: Exception) {
+            throw ex
+        }
+    }
+}

--- a/order/src/main/kotlin/com/study/order/presentation/api/handler/GlobalExceptionHandler.kt
+++ b/order/src/main/kotlin/com/study/order/presentation/api/handler/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.study.order.presentation.api.handler
 import com.study.order.application.exception.CouponException
 import com.study.order.application.exception.OrderException
 import com.study.order.application.exception.ProductException
+import com.study.order.application.exception.RedisException
 import com.study.order.presentation.api.response.Response
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -25,6 +26,11 @@ class GlobalExceptionHandler {
     @ExceptionHandler(CouponException::class)
     fun handleCouponException(ex: CouponException): Response<Unit> {
         return Response(ex.error.status,ex.error.message)
+    }
+
+    @ExceptionHandler(RedisException::class)
+    fun handleRedisException(ex: RedisException): Response<Unit> {
+        return Response(ex.error.status, ex.error.message)
     }
 
 }

--- a/payment/src/main/kotlin/com/study/payment/infrastructure/utils/TransactionHelper.kt
+++ b/payment/src/main/kotlin/com/study/payment/infrastructure/utils/TransactionHelper.kt
@@ -1,18 +1,13 @@
 package com.study.payment.infrastructure.utils
 
 import org.springframework.stereotype.Component
-import org.springframework.transaction.reactive.TransactionalOperator
-import org.springframework.transaction.reactive.executeAndAwait
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @Component
-class TransactionHelper(
-    private val transactionalOperator: TransactionalOperator
-) {
-
-    //    @Transactional(propagation = Propagation.REQUIRES_NEW)
+class TransactionHelper {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     suspend fun executeInNewTransaction(runner: suspend () -> Unit) {
-        transactionalOperator.executeAndAwait {
-            runner()
-        }
+        runner()
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [#73 ]

## 📝 Description

- 주문 생성 시 분산락 도입
- redis hashes 데이터 prefix "product:" / "timeSale:" 로 고정
- 주문 생성 후 결제 완료시까지 타임세일 상품 여부를 확인할 용도의 캐시 데이터 생성
- cacheService 로직 수정
- 코루틴에서 분산 락 사용 시 락 획득 스레드와 해제 스레드가 달라서 발생하는 IllegalMonitorStateException 해결을 위하여 TXID 제공
[참조](https://betterprogramming.pub/dont-use-java-redissonclient-with-kotlin-coroutines-for-distributed-redis-locks-41da2e85c54a)

## 💬 To Reivewers

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?