### PR TITLE
[feature] #55: 상품 재고 차감 API

### DIFF
--- a/product/src/main/java/com/sparta/product/application/dtos/product/ProductResponseDto.java
+++ b/product/src/main/java/com/sparta/product/application/dtos/product/ProductResponseDto.java
@@ -39,7 +39,6 @@ public record ProductResponseDto(
                         .toList())
                 .name(product.getName())
                 .price(product.getPrice())
-                .stock(product.getStock())
                 .build();
     }
 

--- a/product/src/main/java/com/sparta/product/application/exception/common/Error.java
+++ b/product/src/main/java/com/sparta/product/application/exception/common/Error.java
@@ -27,6 +27,8 @@ public enum Error {
 
     NOT_FOUND_PRODUCT(5000, "해당 상품을 찾을 수 없습니다."),
     IS_NOT_SALE_PRODUCT(5001, "판매 중인 상품이 아닙니다."),
+    NOT_FOUND_PRODUCT_IN_REDIS(5002, "redis에서 해당 상품을 찾을 수 없습니다. 조회를 먼저 해주시거나 존재하는 id인지 확인하세요"),
+    NOT_ENOUGH_PRODUCT_STOCK_EXCEPTION(5200, "상품의 재고가 부족합니다. 구매수량 또는 재고 확인이 필요합니다."),
 
     NOT_FOUND_PRODUCTCATEGORY(5050, "상품이나 카테고리를 찾을 수 없습니다. 정상적인 상태인지 확인해주세요."),
 
@@ -36,12 +38,14 @@ public enum Error {
 
     NOT_FOUND_TIMESALE_PRODUCT(7000, "해당 타임세일 상품을 찾을 수 없습니다."),
     NOT_FOUND_ON_TIMESALE_PRODUCT(7001, "진행 중인 타임세일 상품이 아닙니다."),
+    NOT_FOUND_TIMESALE_IN_REDIS(7002, "상품이 redis에 등록되어 있지 않습니다."),
     INVALID_TIMESALE_START_TIME(7100, "시작 시간은 현재 시간 이후여야 합니다."),
     INVALID_TIMESALE_END_TIME(7101, "종료 시간은 시작 시간 이후여야 합니다."),
     DUPLICATE_TIMESALE_PRODUCT(7102, "이미 진행 중이거나 예정된 타임세일이 있습니다."),
     EMPTY_STOCK_EXCEPTION(7103, "재고가 없습니다."),
     TIMESALE_QUANTITY_EXCEED_PRODUCT_STOCK(7300, "상품의 보유 수량을 초과하였습니다."),
     EXCEED_TIMESALE_QUANTITY(7301, "남은 타임세일 재고 수량을 초과하였습니다."),
+    NOT_ENOUGH_TIMESALE_STOCK_IN_DB(7302, "남은 timesale 상품이 없습니다."),
     TIMESALE_SCHEDULE_ERROR(7500, "타임세일 스케줄링 중 오류가 발생했습니다."),
 
     INTERNAL_SERVER_ERROR(9999, "서버 오류입니다."),

--- a/product/src/main/java/com/sparta/product/application/exception/product/NotEnoughProductStockException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/product/NotEnoughProductStockException.java
@@ -1,0 +1,10 @@
+package com.sparta.product.application.exception.product;
+
+import com.sparta.product.application.exception.common.Error;
+import org.springframework.http.HttpStatus;
+
+public class NotEnoughProductStockException extends ProductException {
+    public NotEnoughProductStockException() {
+        super(Error.NOT_ENOUGH_PRODUCT_STOCK_EXCEPTION, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/product/src/main/java/com/sparta/product/application/exception/product/NotFoundProductInRedisException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/product/NotFoundProductInRedisException.java
@@ -1,0 +1,12 @@
+package com.sparta.product.application.exception.product;
+
+import com.sparta.product.application.exception.common.Error;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundProductInRedisException extends ProductException {
+    public NotFoundProductInRedisException() {
+        super(Error.NOT_FOUND_PRODUCT_IN_REDIS, HttpStatus.NOT_FOUND);
+    }
+}

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/NotEnoughTimeSaleStockInDbException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/NotEnoughTimeSaleStockInDbException.java
@@ -1,0 +1,12 @@
+package com.sparta.product.application.exception.timesale;
+
+import com.sparta.product.application.exception.common.Error;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class NotEnoughTimeSaleStockInDbException extends TimeSaleException {
+    public NotEnoughTimeSaleStockInDbException() {
+        super(Error.NOT_ENOUGH_TIMESALE_STOCK_IN_DB, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/product/src/main/java/com/sparta/product/application/exception/timesale/NotFoundTimeSaleInRedisException.java
+++ b/product/src/main/java/com/sparta/product/application/exception/timesale/NotFoundTimeSaleInRedisException.java
@@ -1,0 +1,12 @@
+package com.sparta.product.application.exception.timesale;
+
+import com.sparta.product.application.exception.common.Error;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundTimeSaleInRedisException extends TimeSaleException {
+    public NotFoundTimeSaleInRedisException() {
+        super(Error.NOT_FOUND_TIMESALE_IN_REDIS, HttpStatus.NOT_FOUND);
+    }
+}

--- a/product/src/main/java/com/sparta/product/application/scheduler/TimeSaleSchedulerService.java
+++ b/product/src/main/java/com/sparta/product/application/scheduler/TimeSaleSchedulerService.java
@@ -1,8 +1,7 @@
 package com.sparta.product.application.scheduler;
 
 import com.sparta.product.application.exception.timesale.NotFoundOnTimeSaleException;
-import com.sparta.product.application.scheduler.redis.TimeSaleRedisManager;
-import com.sparta.product.domain.core.Product;
+import com.sparta.product.application.scheduler.redis.RedisManager;
 import com.sparta.product.domain.core.TimeSaleProduct;
 import com.sparta.product.domain.repository.TimeSaleProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,19 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class TimeSaleSchedulerService {
 
     private final TimeSaleProductRepository timeSaleProductRepository;
-    private final TimeSaleRedisManager timeSaleRedisManager;
+    private final RedisManager redisManager;
 
     @Transactional
     public void startTimeSale(Long productId) {
         TimeSaleProduct timeSaleProduct = timeSaleProductRepository.findByProductIdAndIsDeletedFalseAndIsPublicTrue(productId)
                 .orElseThrow(NotFoundOnTimeSaleException::new);
 
-        Product product = timeSaleProduct.getProduct();
-
-        product.updateIsPublic(false);
         timeSaleProduct.updateIsPublic(true);
-
-        log.info("TimeSale started - productId: {}, timeSaleId: {}", product.getId(), timeSaleProduct.getId());
     }
 
     @Transactional
@@ -36,15 +30,10 @@ public class TimeSaleSchedulerService {
         TimeSaleProduct timeSaleProduct = timeSaleProductRepository.findByProductIdAndIsDeletedFalseAndIsPublicTrue(productId)
                 .orElseThrow(NotFoundOnTimeSaleException::new);
 
-        timeSaleRedisManager.removeTimeSaleOn(productId.toString());
-        timeSaleRedisManager.removeEndSchedule(productId.toString());
+//        timeSaleRedisManager.removeTimeSale(productId.toString());
+//        timeSaleRedisManager.removeEndSchedule(productId.toString());
 
-        Product product = timeSaleProduct.getProduct();
-
-        product.updateIsPublic(true);
         timeSaleProduct.updateIsPublic(false);
         timeSaleProduct.getProduct().updateIsPublic(true);
-
-        log.info("TimeSale ended - productId: {}, timeSaleId: {}", product.getId(), timeSaleProduct.getId());
     }
 }

--- a/product/src/main/java/com/sparta/product/application/scheduler/redis/RedisKeys.java
+++ b/product/src/main/java/com/sparta/product/application/scheduler/redis/RedisKeys.java
@@ -4,8 +4,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class RedisKeys {
-    public static final String TIMESALE_START_KEY = "timesale:start";
-    public static final String TIMESALE_END_KEY = "timesale:end";
-    public static final String TIMESALE_ON = "timesale:on:";
-    public static final String PRODUCT = "product";
+    public static final String TIMESALE_START_KEY = "timeSale:start";
+    public static final String TIMESALE_END_KEY = "timeSale:end";
+    public static final String TIMESALE = "timeSale:";
+    public static final String PRODUCT = "product:";
+    public static final String PRODUCT_DETAIL = "product-detail:";
 }

--- a/product/src/main/java/com/sparta/product/application/scheduler/redis/RedisManager.java
+++ b/product/src/main/java/com/sparta/product/application/scheduler/redis/RedisManager.java
@@ -1,5 +1,6 @@
 package com.sparta.product.application.scheduler.redis;
 
+import com.sparta.product.domain.core.Product;
 import com.sparta.product.domain.core.TimeSaleProduct;
 import com.sparta.product.application.exception.scheduler.TimeSaleScheduleException;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,8 +17,12 @@ import java.util.Set;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class TimeSaleRedisManager {
+public class RedisManager {
     private final RedisTemplate<String, String> redisTemplate;
+    private static final String PRODUCT_ID = "product_id";
+    private static final String NAME = "name";
+    private static final String STOCK = "stock";
+    private static final String PRICE = "price";
 
     public void scheduleTimeSale(TimeSaleProduct timeSaleProduct) {
         try {
@@ -34,6 +40,7 @@ public class TimeSaleRedisManager {
                     RedisKeys.TIMESALE_END_KEY,
                     timeSaleProduct.getProduct().getId().toString(),
                     timeSaleProduct.getTimeSaleEndTime().atZone(ZoneId.of("Asia/Seoul"))
+                            .plusDays(1)    // 하루 후에 삭제 되도록 설정
                             .toInstant()
                             .toEpochMilli()
             );
@@ -44,17 +51,44 @@ public class TimeSaleRedisManager {
         }
     }
 
-    public void createTimeSaleProduct(TimeSaleProduct timeSaleProduct) {
-        Map<String, String> productInfo = new HashMap<>();
-        productInfo.put("product_id", timeSaleProduct.getProduct().getId().toString());
-        productInfo.put("name", timeSaleProduct.getProduct().getName());
-        productInfo.put("stock", timeSaleProduct.getStock().toString());
-        productInfo.put("price", timeSaleProduct.getDiscountPrice().toString());
+    public void createHashTimeSale(TimeSaleProduct timeSaleProduct) {
+        Map<String, String> timeSaleInfo = new HashMap<>();
+        timeSaleInfo.put(PRODUCT_ID, timeSaleProduct.getProduct().getId().toString());
+        timeSaleInfo.put(NAME, timeSaleProduct.getProduct().getName());
+        timeSaleInfo.put(STOCK, timeSaleProduct.getStock().toString());
+        timeSaleInfo.put(PRICE, timeSaleProduct.getDiscountPrice().toString());
+
+        String cacheKey = RedisKeys.TIMESALE + timeSaleProduct.getProduct().getId();
 
         redisTemplate.opsForHash().putAll(
-                RedisKeys.TIMESALE_ON + timeSaleProduct.getProduct().getId(),
+                cacheKey,
+                timeSaleInfo
+        );
+
+//        redisTemplate.opsForValue().set(
+//                cacheKey,
+//                timeSaleProduct.getStock().toString()
+//        );
+    }
+
+    public void createHashProduct(Product product) {
+        Map<String, String> productInfo = new HashMap<>();
+        productInfo.put(PRODUCT_ID, product.getId().toString());
+        productInfo.put(NAME, product.getName());
+        productInfo.put(STOCK, product.getStock().toString());
+        productInfo.put(PRICE, product.getPrice().toString());
+
+        String cacheKey = RedisKeys.PRODUCT + product.getId();
+
+        redisTemplate.opsForHash().putAll(
+                cacheKey,
                 productInfo
         );
+
+//        redisTemplate.opsForValue().set(
+//                cacheKey,
+//                product.getStock().toString()
+//        );
     }
 
     public Set<String> getStartTimeSales(long currentTime) {
@@ -81,44 +115,56 @@ public class TimeSaleRedisManager {
         redisTemplate.opsForZSet().remove(RedisKeys.TIMESALE_END_KEY, productId);
     }
 
-    public void removeTimeSaleOn(String productId) {
-        String key = RedisKeys.TIMESALE_ON + productId;
+    public void removeTimeSale(String productId) {
+        String key = RedisKeys.TIMESALE + productId;
         redisTemplate.delete(key);
     }
 
+    public void setExpireTime(String cacheKey, int sec) {
+        redisTemplate.expire(cacheKey, Duration.ofSeconds(sec));
+    }
+
     public boolean checkSoldOut(Long productId) {
-        String key = RedisKeys.TIMESALE_ON + productId;
+        String key = RedisKeys.TIMESALE + productId;
         Map<Object, Object> productInfo = redisTemplate.opsForHash().entries(key);
-        String remainingStock = (String) productInfo.get("stock");
+        String remainingStock = (String) productInfo.get(STOCK);
 
         return remainingStock != null && remainingStock.equals("0");
     }
 
-    public boolean decreaseInventory(Long productId, Integer stock) {
-        String key = RedisKeys.TIMESALE_ON + productId;
-        Map<Object, Object> productInfo = redisTemplate.opsForHash().entries(key);
+    public boolean decreaseHashStock(Long productId, Integer stock, String cacheKey) {
+        Map<Object, Object> productInfo = redisTemplate.opsForHash().entries(cacheKey);
 
         if (!productInfo.isEmpty()) {
-            String remainingStock = (String) productInfo.get("stock");
+            String remainingStock = (String) productInfo.get(STOCK);
             if (remainingStock != null && Integer.parseInt(remainingStock) >= stock) {
                 // 수량 감소
                 int newQuantity = Integer.parseInt(remainingStock) - stock;
-                redisTemplate.opsForHash().put(key, "stock", String.valueOf(newQuantity));
+                redisTemplate.opsForHash().put(cacheKey, STOCK, String.valueOf(newQuantity));
                 return true;
             }
         }
         return false;
     }
 
-    public void increaseInventory(Long productId, Integer stock) {
-        String key = RedisKeys.TIMESALE_ON + productId;
-        Map<Object, Object> productInfo = redisTemplate.opsForHash().entries(key);
+    public void increaseHashStock(Long productId, Integer stock, String cacheKey) {
+        Map<Object, Object> productInfo = redisTemplate.opsForHash().entries(cacheKey);
 
         if (!productInfo.isEmpty()) {
-            String remainingStock = (String) productInfo.get("stock");
+            String remainingStock = (String) productInfo.get(STOCK);
             int newQuantity = (remainingStock != null ? Integer.parseInt(remainingStock) : 0) + stock;
 
-            redisTemplate.opsForHash().put(key, "stock", String.valueOf(newQuantity));
+            redisTemplate.opsForHash().put(cacheKey, STOCK, String.valueOf(newQuantity));
+        }
+    }
+
+    public void updateProductHash(Product product) {
+        String cacheKey = RedisKeys.PRODUCT + product.getId();
+        Map<Object, Object> productInfo = redisTemplate.opsForHash().entries(cacheKey);
+
+        if (!productInfo.isEmpty()) {
+            redisTemplate.opsForHash().put(cacheKey, NAME, product.getName());
+            redisTemplate.opsForHash().put(cacheKey, PRICE, product.getPrice().toString());
         }
     }
 }

--- a/product/src/main/java/com/sparta/product/application/scheduler/redis/TimeSaleScheduler.java
+++ b/product/src/main/java/com/sparta/product/application/scheduler/redis/TimeSaleScheduler.java
@@ -16,7 +16,7 @@ import java.util.Set;
 @Component
 @RequiredArgsConstructor
 public class TimeSaleScheduler {
-    private final TimeSaleRedisManager redisManager;
+    private final RedisManager redisManager;
     private final TimeSaleSchedulerService timeSaleSchedulerService;
     private final TimeSaleProductRepository timeSaleProductRepository;
 
@@ -39,7 +39,7 @@ public class TimeSaleScheduler {
 
                     TimeSaleProduct timeSaleProduct = timeSaleProductRepository.findByProductIdAndIsDeletedFalseAndIsPublicTrue(Long.valueOf(productId))
                             .orElseThrow(NotFoundOnTimeSaleException::new);
-                    redisManager.createTimeSaleProduct(timeSaleProduct);
+                    redisManager.createHashTimeSale(timeSaleProduct);
                 }
             }
         } catch (Exception e) {
@@ -54,7 +54,7 @@ public class TimeSaleScheduler {
             if (endProducts != null && !endProducts.isEmpty()) {
                 for (String productId : endProducts) {
                     redisManager.removeEndSchedule(productId);
-                    redisManager.removeTimeSaleOn(productId);
+                    redisManager.removeTimeSale(productId);
                     timeSaleSchedulerService.endTimeSale(Long.valueOf(productId));
                 }
             }

--- a/product/src/main/java/com/sparta/product/domain/core/Product.java
+++ b/product/src/main/java/com/sparta/product/domain/core/Product.java
@@ -58,7 +58,11 @@ public class Product extends BaseEntity {
         }
     }
 
-    public void decreaseStock(Integer stock) {
-        this.stock -= stock;
+    public void decreaseStock(Integer quantity) {
+        stock -= quantity;
+    }
+
+    public void increaseStock(Integer quantity) {
+        stock += quantity;
     }
 }

--- a/product/src/main/java/com/sparta/product/domain/core/TimeSaleProduct.java
+++ b/product/src/main/java/com/sparta/product/domain/core/TimeSaleProduct.java
@@ -71,7 +71,11 @@ public class TimeSaleProduct extends BaseEntity {
         this.isSoldOut = isSoldOut;
     }
 
-    public void decreaseQuantity(Integer quantity) {
-        this.stock -= quantity;
+    public void decreaseStock(Integer quantity) {
+        stock -= quantity;
+    }
+
+    public void increaseStock(Integer quantity) {
+        stock += quantity;
     }
 }

--- a/product/src/main/java/com/sparta/product/infrastructure/kafka/event/StockDecreaseMessage.java
+++ b/product/src/main/java/com/sparta/product/infrastructure/kafka/event/StockDecreaseMessage.java
@@ -1,11 +1,10 @@
 package com.sparta.product.infrastructure.kafka.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
 
 public record StockDecreaseMessage(
-        @JsonProperty("product_id") @NotNull(message = "상품 ID 입력은 필수입니다.") Long productId,
-        @NotNull(message = "수량 입력은 필수입니다.") Integer stock,
-        @NotNull(message = "필수 값 입니다.") Boolean isDecrease
+        Long productId,
+        Integer quantity,
+        @JsonProperty("decrement") Boolean isDecrease
 ) {
 }

--- a/product/src/main/java/com/sparta/product/infrastructure/kafka/kafkaConsumer.java
+++ b/product/src/main/java/com/sparta/product/infrastructure/kafka/kafkaConsumer.java
@@ -14,22 +14,21 @@ import org.springframework.stereotype.Component;
 public class kafkaConsumer {
 
     private final ProductService productService;
-    private final TimeSaleService timeSaleService;
-    private final ObjectMapper objectMapper;
-
-    private static final String REDIS_STOCK = "redis_stock";
-    private static final String DB_STOCK = "db_stock";
+    private static final String REDIS_STOCK = "product-stock-adjustment";
+    private static final String DB_STOCK = "order-success";
     private static final String PRODUCT_SERVICE = "product-service";
 
-    @KafkaListener(topics = REDIS_STOCK, groupId = PRODUCT_SERVICE)
-    public void receiveRedisMessage(String serializedMessage) {
-        log.info("receiveRedisMessage : {}", serializedMessage);
-        productService.stockManagementInRedis(serializedMessage);
-    }
+//    @KafkaListener(topics = REDIS_STOCK, groupId = PRODUCT_SERVICE)
+//    public void receiveRedisMessage(String serializedMessage) {
+//        log.info("receiveRedisMessage : {}", serializedMessage);
+//        String replaceMessage = serializedMessage.replace("[", "").replace("]", "");
+//        productService.stockManagementInRedis(replaceMessage);
+//    }
 
     @KafkaListener(topics = DB_STOCK, groupId = PRODUCT_SERVICE)
     public void receiveDbStock(String serializedMessage) {
         log.info("receiveDbStock: {}", serializedMessage);
-        productService.stockManagementInDb(serializedMessage);
+        String replaceMessage = serializedMessage.replace("[", "").replace("]", "");
+        productService.stockManagementInDb(replaceMessage);
     }
 }

--- a/product/src/main/java/com/sparta/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/sparta/product/presentation/controller/ProductController.java
@@ -40,13 +40,11 @@ public class ProductController {
     }
 
     @PatchMapping("/{productId}")
-    public Response<ProductResponseDto> updateProduct(@PathVariable Long productId,
+    public Response<Void> updateProduct(@PathVariable Long productId,
                                                       @RequestBody @Valid ProductUpdateRequestDto productUpdateRequestDto,
                                                       @RequestHeader(name = "X-UserId", required = false) String userId,
                                                       @RequestHeader(name = "X-Role") String role) {
-        return Response.<ProductResponseDto>builder()
-                .data(productService.updateProduct(productId, role, productUpdateRequestDto))
-                .build();
+        return Response.<Void>builder().build();
     }
 
     @DeleteMapping("/{productId}")
@@ -57,14 +55,9 @@ public class ProductController {
         return Response.<Void>builder().build();
     }
 
-    @PostMapping("/product-stock-decrease-db")
-    public Response<Void> decreaseStockInDb(@RequestBody StockDecreaseMessage stockDecreaseMessage) {
-        productService.decreaseStockInDb(stockDecreaseMessage.productId(), stockDecreaseMessage.stock());
+    @PostMapping("/stock-management")
+    public Response<Void> decreaseStockInDb(@RequestBody String serializedMessage) {
+        productService.stockManagementInDb(serializedMessage);
         return Response.<Void>builder().build();
-    }
-
-    @GetMapping("/internal/{productId}")
-    public ProductInternalResponseDto internalGetProduct(@PathVariable Long productId) {
-        return productService.internalGetProduct(productId);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #55 

## 📝 Description

- 상품에서 hash로된 product:, timeSale: 의 재고 정보는 수정하지 않고 생성만 해주기로 코드 변경
- product detail에서 재고 정보 제거
- 재고 변경 요청이 오면 timeSale: 에 등록된 제품인지 확인 후 없으면 DB의 product 재고만 수정, timeSale:에 있는 제품이면 DB에 둘다 같이 재고 수정 되는 것 확인.

## 💬 To Reivewers

- 코드가 좀 지저분 할 수 있습니다. 이전에 작성했던 코드들 지우지 않은 부분이 있어요.. 혹시 나중에 참고해서 작성할 수도 있을까봐.. ㅠㅠ